### PR TITLE
Add exclusions filter for killer cage options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ function Input(props: HTMLProps<HTMLInputElement>) {
 export function InnerApp() {
   const [total, setTotal] = useState<number>(10);
   const [size, setSize] = useState<number>(3);
+  const [exclusions, setExclusions] = useState<string>('');
 
   return (
     <div className="auto px-10 my-10">
@@ -29,9 +30,13 @@ export function InnerApp() {
             Size:
             <Input type="number" max={9} min={1} name={'size'} value={size.toString() ?? ''} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSize(Number(e.target.value))} />
           </label>
+          <label>
+            Disallowed Numbers:
+            <Input name={'exclusions'} value={exclusions} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setExclusions(e.target.value)} placeholder="e.g. 1 2 3" />
+          </label>
         </div>
       </div>
-      <Cage total={total} size={size} />
+      <Cage total={total} size={size} exclusions={exclusions} />
     </div>
   );
 }

--- a/src/stories/Cage.stories.tsx
+++ b/src/stories/Cage.stories.tsx
@@ -13,5 +13,6 @@ export const Default: Story = {
   args: {
     size: 3,
     total: 10,
+    exclusions: '',
   },
 };

--- a/src/ui/Cage.tsx
+++ b/src/ui/Cage.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { range, validCombinations } from '../utils';
+import { range, combinations, numStrToArr, ensureUniqueNumbers } from '../utils';
 import NumberTile from './NumberTile';
 
 interface CageProps {
   total: number;
   size: number;
+  exclusions?: string;
 }
 
 function toggleIndex(indexes: number[], index: number): number[] {
@@ -19,8 +20,9 @@ function toggleIndex(indexes: number[], index: number): number[] {
   return [...indexes];
 }
 
-export default function Cage({ total, size }: CageProps) {
-  const combinations = validCombinations(total, size);
+export default function Cage({ total, size, exclusions = '' }: CageProps) {
+  const excludedNumbers = ensureUniqueNumbers(numStrToArr(exclusions));
+  const comboList = combinations(total, size, [], excludedNumbers);
 
   const [excludedIndexes, setExcludedIndexes] = useState<number[]>([]);
 
@@ -34,7 +36,7 @@ export default function Cage({ total, size }: CageProps) {
         {size} cell, {total} cage
       </h2>
       <div>
-        {combinations.map((combination, i) => (
+        {comboList.map((combination, i) => (
           <div
             className={excludedIndexes.indexOf(i) > -1 ? 'opacity-20' : ''}
             key={`cage-option-${i}`}


### PR DESCRIPTION
## Summary
- add exclusions input to specify numbers to disallow
- compute combinations using those disallowed numbers
- update Cage storybook story

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bd7f8f20832f878b45d5773ba665