### PR TITLE
Add unit tests for utils

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,39 @@
+import { range, numStrToArr, ensureUniqueNumbers } from './utils';
+
+describe('range', () => {
+  it('creates an increasing range', () => {
+    expect(range(1, 3)).toEqual([1, 2, 3]);
+  });
+
+  it('creates a decreasing range', () => {
+    expect(range(3, 1)).toEqual([3, 2, 1]);
+  });
+
+  it('returns single value when start equals end', () => {
+    expect(range(2, 2)).toEqual([2]);
+  });
+
+  it('floors decimal values', () => {
+    expect(range(1.9, 3.2)).toEqual([1, 2, 3]);
+  });
+});
+
+describe('numStrToArr', () => {
+  it('converts a space separated string to an array of numbers', () => {
+    expect(numStrToArr('1 2 3')).toEqual([1, 2, 3]);
+  });
+
+  it('filters out invalid numbers', () => {
+    expect(numStrToArr('1 10 a 5 0 9')).toEqual([1, 5, 9]);
+  });
+});
+
+describe('ensureUniqueNumbers', () => {
+  it('removes duplicates while preserving order', () => {
+    expect(ensureUniqueNumbers([1, 2, 2, 3, 1])).toEqual([1, 2, 3]);
+  });
+
+  it('returns an empty array as-is', () => {
+    expect(ensureUniqueNumbers([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest unit tests for `range`, `numStrToArr`, and `ensureUniqueNumbers`

## Testing
- `npm test -- -w=1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e0490cf0832f96500cdb4bcffe74