### PR TITLE
Remove unused useState from index.tsx

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import { InnerApp } from './App';


### PR DESCRIPTION
## Summary
- remove unused `useState` from the React import in `src/index.tsx`

## Testing
- `CI=true npm test -- -u` *(fails: react-scripts not found)*
- `npm install` *(fails: network or environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6843b8785f3c832f8d6896fd4e2afff6