### PR TITLE
Add inclusions filter for cage options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ export function InnerApp() {
   const [total, setTotal] = useState<number>(10);
   const [size, setSize] = useState<number>(3);
   const [exclusions, setExclusions] = useState<string>('');
+  const [inclusions, setInclusions] = useState<string>('');
 
   return (
     <div className="mx-auto px-10 my-10">
@@ -34,9 +35,13 @@ export function InnerApp() {
             Disallowed Numbers:
             <Input name={'exclusions'} value={exclusions} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setExclusions(e.target.value)} placeholder="e.g. 1 2 3" />
           </label>
+          <label>
+            Required Numbers:
+            <Input name={'inclusions'} value={inclusions} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setInclusions(e.target.value)} placeholder="e.g. 1 2" />
+          </label>
         </div>
       </div>
-      <Cage total={total} size={size} exclusions={exclusions} />
+      <Cage total={total} size={size} exclusions={exclusions} inclusions={inclusions} />
     </div>
   );
 }

--- a/src/stories/Cage.stories.tsx
+++ b/src/stories/Cage.stories.tsx
@@ -14,5 +14,6 @@ export const Default: Story = {
     size: 3,
     total: 10,
     exclusions: '',
+    inclusions: '',
   },
 };

--- a/src/ui/Cage.tsx
+++ b/src/ui/Cage.tsx
@@ -6,6 +6,7 @@ interface CageProps {
   total: number;
   size: number;
   exclusions?: string;
+  inclusions?: string;
 }
 
 function toggleIndex(indexes: number[], index: number): number[] {
@@ -20,9 +21,10 @@ function toggleIndex(indexes: number[], index: number): number[] {
   return [...indexes];
 }
 
-export default function Cage({ total, size, exclusions = '' }: CageProps) {
+export default function Cage({ total, size, exclusions = '', inclusions = '' }: CageProps) {
   const excludedNumbers = ensureUniqueNumbers(numStrToArr(exclusions));
-  const comboList = combinations(total, size, [], excludedNumbers);
+  const includedNumbers = ensureUniqueNumbers(numStrToArr(inclusions));
+  const comboList = combinations(total, size, includedNumbers, excludedNumbers);
 
   const [excludedIndexes, setExcludedIndexes] = useState<number[]>([]);
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { range, numStrToArr, ensureUniqueNumbers } from './utils';
+import { range, numStrToArr, ensureUniqueNumbers, combinations } from './utils';
 
 describe('range', () => {
   it('creates an increasing range', () => {
@@ -35,5 +35,15 @@ describe('ensureUniqueNumbers', () => {
 
   it('returns an empty array as-is', () => {
     expect(ensureUniqueNumbers([])).toEqual([]);
+  });
+});
+
+describe('combinations', () => {
+  it('filters combinations by inclusions', () => {
+    expect(combinations(5, 2, [1], [])).toEqual([[1, 4]]);
+  });
+
+  it('filters combinations by inclusions and exclusions', () => {
+    expect(combinations(5, 2, [1], [4])).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- allow specifying numbers that must appear in a cage
- wire inclusions through to Cage component and storybook
- test combinations with inclusions

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c7da135c832fb4c7a79532f6c87e